### PR TITLE
Support scripts now handle multiple ARCH types

### DIFF
--- a/setup.sh
+++ b/setup.sh
@@ -1,6 +1,7 @@
 #!/bin/bash
 
 REGIONS=('us-east-2' 'us-west-2')
+ARCHS=('x86_64' 'arm64')
 
 cd `dirname $0`/utility
 
@@ -13,13 +14,12 @@ cd `dirname $0`/utility
 for region in ${REGIONS[*]}; do
 	# Deploy dataset for training and testing into an S3 bucket
 	./deploy_dataset_s3.sh $region
-	# Deploy Docker image using ecr
-	./deploy_ecr.sh amd64 $region
-	./deploy_ecr.sh arm64 $region
-	# Deploy all lambda functions for arm64 and x86_64
-	./deploy_lambda_function.sh x86_64 $region
-	./deploy_lambda_function.sh arm64 $region
-	# Create S3 buckets for both arm64 and x86_64
-	./make_s3_bucket.sh x86_64 $region
-	./make_s3_bucket.sh aarch64 $region
+	for arch in ${ARCHS[*]}; do
+		# Deploy Docker image using ecr
+		./deploy_ecr.sh $arch $region
+		# Deploy all lambda functions for arm64 and x86_64
+		./deploy_lambda_function.sh $arch $region
+		# Create S3 buckets for both arm64 and x86_64
+		./make_s3_bucket.sh $arch $region
+	done
 done

--- a/utility/deploy_ecr.sh
+++ b/utility/deploy_ecr.sh
@@ -4,17 +4,22 @@ cd `dirname $0`/..
 
 # Allow users to set the arch
 if [[ -z "$1" && -z "$ARCH" ]]; then
-	case $(uname -m) in
-		x86_64)
-			ARCH='amd64'
-			;;
-		aarch64)
-			ARCH='arm64'
-			;;
-	esac
+	ARCH=$(uname -m)
 elif [ -n "$1" ]; then
 	ARCH=$1
 fi
+case $ARCH in
+	x86_64|amd64)
+		ARCH='amd64'
+		;;
+	aarch64|arm64)
+		ARCH='arm64'
+		;;
+	*)
+		echo "ERROR: $ARCH not supported"
+		exit 1
+		;;
+esac
 
 # Allow users to set the region
 if [[ -z "$2" && -z "$REGION" ]]; then

--- a/utility/deploy_lambda_function.sh
+++ b/utility/deploy_lambda_function.sh
@@ -26,17 +26,22 @@ create_role() {
 
 # Allow users to set the arch
 if [[ -z "$1" && -z "$ARCH" ]]; then
-	case $(uname -m) in
-		x86_64)
-			ARCH='x86_64'
-			;;
-		aarch64)
-			ARCH='arm64'
-			;;
-	esac
+	ARCH=$(uname -m)
 elif [ -n "$1" ]; then
 	ARCH="$1"
 fi
+case $ARCH in
+	x86_64|amd64)
+		ARCH='x86_64'
+		;;
+	aarch64|arm64)
+		ARCH='arm64'
+		;;
+	*)
+		echo "ERROR: $ARCH not supported"
+		exit 1
+		;;
+esac
 
 # Allow users to set the region
 if [[ -z "$2" && -z "$REGION" ]]; then

--- a/utility/install_docker.sh
+++ b/utility/install_docker.sh
@@ -41,12 +41,14 @@ if ! which docker > /dev/null; then
 	sudo usermod -aG docker $USER
 fi
 
-# Install biuldx
-mkdir -p "$(dirname $BUILDX_PATH)"
-wget "https://github.com/docker/buildx/releases/download/$BUILDX_VERSION/buildx-$BUILDX_VERSION.linux-$ARCH" -O "$BUILDX_PATH"
-chmod +x "$BUILDX_PATH"
-# Setup an alias "docker buildx install"->"docker build"
-docker buildx install
+# Install buildx
+if [ ! -f "$BUILDX_PATH" ]; then
+	mkdir -p "$(dirname $BUILDX_PATH)"
+	wget "https://github.com/docker/buildx/releases/download/$BUILDX_VERSION/buildx-$BUILDX_VERSION.linux-$ARCH" -O "$BUILDX_PATH"
+	chmod +x "$BUILDX_PATH"
+fi
 
 # Install multi-arch dependencies
-sudo apt-get update && sudo apt-get install -y binfmt-support qemu-user-static
+if ! dpkg -s binfmt-support &> /dev/null || ! dpkg -s qemu-user-static &> /dev/null; then
+	sudo apt-get update && sudo apt-get install -y binfmt-support qemu-user-static
+fi

--- a/utility/make_s3_bucket.sh
+++ b/utility/make_s3_bucket.sh
@@ -6,7 +6,18 @@ if [[ -z "$1" && -z "$ARCH" ]]; then
 elif [ -n "$1" ]; then
 	ARCH=$1
 fi
-ARCH=$(echo $ARCH | tr '_' '-')
+case $ARCH in
+	x86_64|amd64)
+		ARCH='x86-64'
+		;;
+	aarch64|arm64)
+		ARCH='aarch64'
+		;;
+	*)
+		echo "ERROR: $ARCH not supported"
+		exit 1
+		;;
+esac
 
 # Allow users to set the region
 if [[ -z "$2" && -z "$REGION" ]]; then


### PR DESCRIPTION
- All support scripts will now handle their own ARCH string dependencies.
- install_docker.sh now checks if buildx support is present before installing
additional packages.

Signed-off-by: Bob Schmitz III <14095796+rgschmitz1@users.noreply.github.com>